### PR TITLE
catch HTTPError in fetcher.fetch_artists()

### DIFF
--- a/wikiart/fetcher.py
+++ b/wikiart/fetcher.py
@@ -160,7 +160,7 @@ class WikiArtFetcher:
         page = response.json()
       except HTTPError as error:
         error = error.response.status_code
-        log.write('Error %s' % str(error))
+        log.write('Error Response Status Code %s' % str(error))
         interrupted = True
         break
 

--- a/wikiart/fetcher.py
+++ b/wikiart/fetcher.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from urllib.parse import unquote
 
 import requests
+from requests.exceptions import HTTPError
 
 from . import base, settings
 from .base import log
@@ -157,7 +158,8 @@ class WikiArtFetcher:
         response = requests.get(url, params, timeout=settings.METADATA_REQUEST_TIMEOUT)
         response.raise_for_status()
         page = response.json()
-      except Exception as error:
+      except HTTPError as error:
+        error = error.response.status_code
         log.write('Error %s' % str(error))
         interrupted = True
         break

--- a/wikiart/fetcher.py
+++ b/wikiart/fetcher.py
@@ -160,7 +160,7 @@ class WikiArtFetcher:
         page = response.json()
       except HTTPError as error:
         error = error.response.status_code
-        log.write('Error Response Status Code %s' % str(error))
+        log.write(f'Error Response Status Code {str(error)}')
         interrupted = True
         break
 


### PR DESCRIPTION
changes `except Exception as error:` to `except HTTPError as error:` on line 161 to catch and log the response error code.