### PR TITLE
user-friendly warning on slow metadata retrievals

### DIFF
--- a/wikiart/fetcher.py
+++ b/wikiart/fetcher.py
@@ -132,7 +132,7 @@ class WikiArtFetcher:
 
     def fetch_artist(self, artist_name):
         """Fetch Paintings Metadata for One Artist"""
-        Logger.write('\nFetching paintings for artist: {}'.format(artist_name))
+        Logger.write('\nFetching paintings of artist: {} (Metadata retrieval is slow and can take minutes. Please be patient)'.format(artist_name))
         if not self.artists:
             raise RuntimeError('No artists defined. Cannot continue.')
 


### PR DESCRIPTION
The metadata retrieval per artist takes long time. Actually painfully long time for me, around (300 seconds) for an artist today. Not sure if it's my connection being rate-limited or what. Anyway, I presume users if in this situation and when they don't see any files yet under the data/images/<artist name>, they might abort the command thinking something is wrong. So I added a helpful message hinting they should be patient :)

Onwards, we should look into the logic and see why it's slow. My gut feel (without having looked the code in depth yet) is that the artist metadata is being processed in probably a less efficient way to get the individual artist details out and making lot of calls to the wikiart site, and probably getting rate-limited there. But this is just pure guessing. I'll look at this later when I get some time.